### PR TITLE
feat: Set NoDisplay=true for vim.desktop

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vim (2:9.2.0218-1deepin1) unstable; urgency=medium
+
+  * Set NoDisplay=true for vim.desktop
+
+ -- lichenggang <lichenggang@uniontech.com>  Mon, 23 Mar 2026 10:45:09 +0800
+
 vim (2:9.2.0218-1) unstable; urgency=medium
 
   * New upstream tag

--- a/debian/patches/Set-NoDisplay-true-for-vim-desktop.patch
+++ b/debian/patches/Set-NoDisplay-true-for-vim-desktop.patch
@@ -1,0 +1,36 @@
+From: Tianyu Chen <sweetyfish@deepin.org>
+Date: Thu, 15 Jan 2026 10:17:18 +0800
+Subject: Set NoDisplay=true for vim.desktop
+
+Origin: vendor
+Bug-deepin: https://pms.uniontech.com/bug-view-285241.html
+Forwarded: not-needed
+---
+ runtime/vim.desktop   | 1 +
+ src/po/vim.desktop.in | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/runtime/vim.desktop b/runtime/vim.desktop
+index a8672cb..715d071 100644
+--- a/runtime/vim.desktop
++++ b/runtime/vim.desktop
+@@ -111,6 +111,7 @@ Comment[zh_TW]=編輯文字檔
+ TryExec=vim
+ Exec=vim %F
+ Terminal=true
++NoDisplay=true
+ Type=Application
+ # Translators: Search terms to find this application. Do NOT change the semicolons! The list MUST also end with a semicolon!
+ Keywords[ca]=Text;editor;
+diff --git a/src/po/vim.desktop.in b/src/po/vim.desktop.in
+index 874fa6a..958f66e 100644
+--- a/src/po/vim.desktop.in
++++ b/src/po/vim.desktop.in
+@@ -69,6 +69,7 @@ Comment[zh_TW]=編輯文字檔
+ TryExec=vim
+ Exec=vim %F
+ Terminal=true
++NoDisplay=true
+ Type=Application
+ # Translators: Search terms to find this application. Do NOT change the semicolons! The list MUST also end with a semicolon!
+ Keywords=Text;editor;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -3,3 +3,4 @@ debian/Detect-the-rst-filetype-using-the-contents-of-the-file.patch
 debian/Add-recognition-of-more-LaTeX-commands-for-tex-filetype-d.patch
 debian/Document-Debian-s-decision-to-disable-modelines-by-defaul.patch
 Revert-patch-9.1.0949-popups-inconsistently-shifted-to-th.patch
+Set-NoDisplay-true-for-vim-desktop.patch


### PR DESCRIPTION
Hide vim from desktop application menu by setting NoDisplay=true This prevents vim from appearing in the desktop application launcher The desktop editor (gvim) should be used instead for GUI purposes Vim in terminal is still accessible through command line This change improves the user experience by avoiding confusion

Log: Added NoDisplay=true to vim.desktop files

Influence:
1. Test that vim no longer appears in desktop application launcher
2. Verify that gvim still appears in desktop launcher
3. Confirm that starting vim from terminal still works
4. Check that other desktop entries remain unaffected
5. Ensure no regression in desktop environment integration

feat: 为 vim.desktop 设置 NoDisplay=true

通过设置 NoDisplay=true 隐藏 vim 桌面应用
这防止 vim 出现在桌面应用启动器中
应该使用桌面编辑器 (gvim) 进行图形界面操作
终端中的 vim 仍然可以通过命令行访问
此更改改进用户体验，避免混淆

Log: 为 vim.desktop 文件添加 NoDisplay=true

Influence:
1. 测试 vim 不再出现在桌面应用启动器中
2. 验证 gvim 仍然出现在桌面启动器中
3. 确认从终端启动 vim 仍然正常工作
4. 检查其他桌面条目不受影响
5. 确保桌面环境集成无回归

repo: vim #debian/9.2.0218