### PR TITLE
patch 9.2.0272: [security]: 'tabpanel' can be set in a modeline

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+vim (2:9.2.0218-1deepin3) unstable; urgency=medium
+
+  * patch 9.2.0276: [security]: modeline security bypass
+    Fixes: CVE-2026-34982 (GHSA-8h6p-m6gr-mpw9)
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Wed, 01 Apr 2026 10:39:23 +0800
+
 vim (2:9.2.0218-1deepin2) unstable; urgency=medium
 
   * patch 9.2.0272: [security]: 'tabpanel' can be set in a modeline

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+vim (2:9.2.0218-1deepin2) unstable; urgency=medium
+
+  * patch 9.2.0272: [security]: 'tabpanel' can be set in a modeline
+    Fixes: CVE-2026-34714 (GHSA-2gmj-rpqf-pxvh)
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Tue, 31 Mar 2026 11:42:59 +0800
+
 vim (2:9.2.0218-1deepin1) unstable; urgency=medium
 
   * Set NoDisplay=true for vim.desktop

--- a/debian/patches/Set-NoDisplay-true-for-vim-desktop.patch
+++ b/debian/patches/Set-NoDisplay-true-for-vim-desktop.patch
@@ -11,10 +11,10 @@ Forwarded: not-needed
  2 files changed, 2 insertions(+)
 
 diff --git a/runtime/vim.desktop b/runtime/vim.desktop
-index a8672cb..715d071 100644
+index 45f6c20..341474f 100644
 --- a/runtime/vim.desktop
 +++ b/runtime/vim.desktop
-@@ -111,6 +111,7 @@ Comment[zh_TW]=編輯文字檔
+@@ -112,6 +112,7 @@ Comment[zh_TW]=編輯文字檔
  TryExec=vim
  Exec=vim %F
  Terminal=true
@@ -23,10 +23,10 @@ index a8672cb..715d071 100644
  # Translators: Search terms to find this application. Do NOT change the semicolons! The list MUST also end with a semicolon!
  Keywords[ca]=Text;editor;
 diff --git a/src/po/vim.desktop.in b/src/po/vim.desktop.in
-index 874fa6a..958f66e 100644
+index c603143..5394e53 100644
 --- a/src/po/vim.desktop.in
 +++ b/src/po/vim.desktop.in
-@@ -69,6 +69,7 @@ Comment[zh_TW]=編輯文字檔
+@@ -67,6 +67,7 @@ Comment[zh_TW]=編輯文字檔
  TryExec=vim
  Exec=vim %F
  Terminal=true

--- a/debian/patches/patch-9.2.0272-security-tabpanel-can-be-set-in-a-modeline.patch
+++ b/debian/patches/patch-9.2.0272-security-tabpanel-can-be-set-in-a-modeline.patch
@@ -1,0 +1,85 @@
+From: Christian Brabandt <cb@256bit.org>
+Date: Mon, 30 Mar 2026 08:20:43 +0000
+Subject: patch 9.2.0272: [security]: 'tabpanel' can be set in a modeline
+
+Problem:  'tabpanel' can be set in a modeline
+Solution: Set the P_MLE flag for the 'tabpanel' option, disable
+          autocmd_add()/autocomd_delete() functions in restricted/secure
+          mode.
+
+Github Advisory:
+https://github.com/vim/vim/security/advisories/GHSA-2gmj-rpqf-pxvh
+
+Signed-off-by: Christian Brabandt <cb@256bit.org>
+---
+ src/autocmd.c                 |  3 +++
+ src/optiondefs.h              |  2 +-
+ src/testdir/test_autocmd.vim  |  5 +++++
+ src/testdir/test_tabpanel.vim | 15 +++++++++++++++
+ 4 files changed, 24 insertions(+), 1 deletion(-)
+
+diff --git a/src/autocmd.c b/src/autocmd.c
+index e6b6ecb..8fe51dc 100644
+--- a/src/autocmd.c
++++ b/src/autocmd.c
+@@ -3061,6 +3061,9 @@ autocmd_add_or_delete(typval_T *argvars, typval_T *rettv, int delete)
+     rettv->v_type = VAR_BOOL;
+     rettv->vval.v_number = VVAL_FALSE;
+ 
++    if (check_restricted() || check_secure())
++	return;
++
+     if (check_for_list_arg(argvars, 0) == FAIL)
+ 	return;
+ 
+diff --git a/src/optiondefs.h b/src/optiondefs.h
+index 40733fd..fec4456 100644
+--- a/src/optiondefs.h
++++ b/src/optiondefs.h
+@@ -2578,7 +2578,7 @@ static struct vimoption options[] =
+ 			    (char_u *)&p_tpm, PV_NONE, NULL, NULL,
+ 			    {(char_u *)10L, (char_u *)0L} SCTX_INIT},
+ #if defined(FEAT_TABPANEL)
+-    {"tabpanel",  "tpl",    P_STRING|P_VI_DEF|P_RALL,
++    {"tabpanel",  "tpl",    P_STRING|P_VI_DEF|P_RALL|P_MLE,
+ 			    (char_u *)&p_tpl, PV_NONE, NULL, NULL,
+ 			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
+     {"tabpanelopt","tplo",  P_STRING|P_ALLOCED|P_VI_DEF|P_ONECOMMA|P_COLON
+diff --git a/src/testdir/test_autocmd.vim b/src/testdir/test_autocmd.vim
+index 084dd7a..c7bd153 100644
+--- a/src/testdir/test_autocmd.vim
++++ b/src/testdir/test_autocmd.vim
+@@ -5835,4 +5835,9 @@ func Test_win_tabclose_autocmd()
+   bw!
+ endfunc
+ 
++func Test_autocmd_add_secure()
++  call assert_fails('sandbox call autocmd_add([{"event": "BufRead", "cmd": "let x = 1"}])', 'E48:')
++  call assert_fails('sandbox call autocmd_delete([{"event": "BufRead"}])', 'E48:')
++endfunc
++
+ " vim: shiftwidth=2 sts=2 expandtab
+diff --git a/src/testdir/test_tabpanel.vim b/src/testdir/test_tabpanel.vim
+index 556cc3b..4837a64 100644
+--- a/src/testdir/test_tabpanel.vim
++++ b/src/testdir/test_tabpanel.vim
+@@ -872,4 +872,19 @@ function Test_tabpanel_showtabpanel_via_cmd_arg()
+   set showtabpanel& noruler&
+ endfunc
+ 
++func Test_tabpanel_no_modeline()
++  let _tpl = &tabpanel
++  let _mls = &modelineexpr
++
++  set nomodelineexpr
++  setlocal modeline
++  new
++  call writefile(['/* vim: set tabpanel=test: */'], 'Xtabpanel.txt', 'D')
++  call assert_fails(':e Xtabpanel.txt', 'E992:')
++
++  let &tabpanel = _tpl
++  let &modelineexpr = _mls
++  bw!
++endfunc
++
+ " vim: shiftwidth=2 sts=2 expandtab

--- a/debian/patches/patch-9.2.0276-security-modeline-security-bypass.patch
+++ b/debian/patches/patch-9.2.0276-security-modeline-security-bypass.patch
@@ -1,0 +1,97 @@
+From: Christian Brabandt <cb@256bit.org>
+Date: Tue, 31 Mar 2026 18:29:00 +0000
+Subject: patch 9.2.0276: [security]: modeline security bypass
+
+Problem:  [security]: modeline security bypass
+Solution: disallow mapset() from secure mode, set the P_MLE flag for the
+          'complete', 'guitabtooltip' and 'printheader' options.
+
+Github Advisory:
+https://github.com/vim/vim/security/advisories/GHSA-8h6p-m6gr-mpw9
+
+Signed-off-by: Christian Brabandt <cb@256bit.org>
+---
+ src/map.c                     |  3 +++
+ src/optiondefs.h              |  6 +++---
+ src/testdir/test_modeline.vim | 25 +++++++++++++++++++++++++
+ 3 files changed, 31 insertions(+), 3 deletions(-)
+
+diff --git a/src/map.c b/src/map.c
+index 0a909fb..5f07ef4 100644
+--- a/src/map.c
++++ b/src/map.c
+@@ -2746,6 +2746,9 @@ f_mapset(typval_T *argvars, typval_T *rettv UNUSED)
+     int		dict_only;
+     mapblock_T	*mp_result[2] = {NULL, NULL};
+ 
++    if (check_secure())
++	return;
++
+     // If first arg is a dict, then that's the only arg permitted.
+     dict_only = argvars[0].v_type == VAR_DICT;
+     if (in_vim9script()
+diff --git a/src/optiondefs.h b/src/optiondefs.h
+index fec4456..ddf1dd8 100644
+--- a/src/optiondefs.h
++++ b/src/optiondefs.h
+@@ -681,7 +681,7 @@ static struct vimoption options[] =
+     {"compatible",  "cp",   P_BOOL|P_RALL,
+ 			    (char_u *)&p_cp, PV_NONE, did_set_compatible, NULL,
+ 			    {(char_u *)TRUE, (char_u *)FALSE} SCTX_INIT},
+-    {"complete",    "cpt",  P_STRING|P_ALLOCED|P_VI_DEF|P_ONECOMMA|P_NODUP,
++    {"complete",    "cpt",  P_STRING|P_ALLOCED|P_VI_DEF|P_ONECOMMA|P_NODUP|P_MLE,
+ 			    (char_u *)&p_cpt, PV_CPT, did_set_complete, expand_set_complete,
+ 			    {(char_u *)".,w,b,u,t,i", (char_u *)0L}
+ 			    SCTX_INIT},
+@@ -1324,7 +1324,7 @@ static struct vimoption options[] =
+ 			    {(char_u *)NULL, (char_u *)0L}
+ #endif
+ 			    SCTX_INIT},
+-    {"guitabtooltip",  "gtt", P_STRING|P_VI_DEF|P_RWIN,
++    {"guitabtooltip",  "gtt", P_STRING|P_VI_DEF|P_RWIN|P_MLE,
+ #if defined(FEAT_GUI_TABLINE)
+ 			    (char_u *)&p_gtt, PV_NONE, NULL, NULL,
+ 			    {(char_u *)"", (char_u *)0L}
+@@ -2041,7 +2041,7 @@ static struct vimoption options[] =
+ 			    {(char_u *)NULL, (char_u *)0L}
+ #endif
+ 			    SCTX_INIT},
+-    {"printheader", "pheader",  P_STRING|P_VI_DEF|P_GETTEXT,
++    {"printheader", "pheader",  P_STRING|P_VI_DEF|P_GETTEXT|P_MLE,
+ #ifdef FEAT_PRINTER
+ 			    (char_u *)&p_header, PV_NONE, NULL, NULL,
+ 			    // untranslated to avoid problems when 'encoding'
+diff --git a/src/testdir/test_modeline.vim b/src/testdir/test_modeline.vim
+index 4cc091b..25ca6fb 100644
+--- a/src/testdir/test_modeline.vim
++++ b/src/testdir/test_modeline.vim
+@@ -490,4 +490,29 @@ func Test_modeline_nowrap_lcs_extends()
+   set equalalways&
+ endfunc
+ 
++func Test_modeline_forbidden()
++  let tempfile = tempname()
++  let lines =<< trim END
++    some test text for completion
++    vim: set complete=F{->system('touch_should_not_run')} :
++  END
++  call writefile(lines, tempfile, 'D')
++  call assert_fails($'new {tempfile}', 'E992:')
++  bw!
++  let lines =<< trim END
++    some text
++    vim: set guitabtooltip=%{%mapset()%}:
++  END
++  call writefile(lines, tempfile)
++  call assert_fails($'new {tempfile}', 'E992:')
++  bw!
++  let lines =<< trim END
++    some text
++    vim: set printheader=%{mapset('n',0,{})%)%}:
++  END
++  call writefile(lines, tempfile, 'D')
++  call assert_fails($'new {tempfile}', 'E992:')
++  bw!
++endfunc
++
+ " vim: shiftwidth=2 sts=2 expandtab

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@ debian/Document-Debian-s-decision-to-disable-modelines-by-defaul.patch
 Revert-patch-9.1.0949-popups-inconsistently-shifted-to-th.patch
 Set-NoDisplay-true-for-vim-desktop.patch
 patch-9.2.0272-security-tabpanel-can-be-set-in-a-modeline.patch
+patch-9.2.0276-security-modeline-security-bypass.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,3 +4,4 @@ debian/Add-recognition-of-more-LaTeX-commands-for-tex-filetype-d.patch
 debian/Document-Debian-s-decision-to-disable-modelines-by-defaul.patch
 Revert-patch-9.1.0949-popups-inconsistently-shifted-to-th.patch
 Set-NoDisplay-true-for-vim-desktop.patch
+patch-9.2.0272-security-tabpanel-can-be-set-in-a-modeline.patch


### PR DESCRIPTION
- patch 9.2.0272: [security]: 'tabpanel' can be set in a modeline
   Fixes: CVE-2026-34714 (GHSA-2gmj-rpqf-pxvh)
- patch 9.2.0276: [security]: modeline security bypass
   Fixes: CVE-2026-34982 (GHSA-8h6p-m6gr-mpw9)


